### PR TITLE
feat(security): add basic session registeration and secure participant visibility

### DIFF
--- a/src/main/java/com/kkmalysa/myownplanningpoker/model/Room.java
+++ b/src/main/java/com/kkmalysa/myownplanningpoker/model/Room.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Data
@@ -14,6 +15,22 @@ public class Room {
     private String id;
     private Map<String, Player> players = new ConcurrentHashMap<>();
     private boolean revealed = false;
+    private Set<String> allowedSessions = ConcurrentHashMap.newKeySet();
+
+    public Room(String id, Map<String, Player> players, boolean revealed) {
+        this.id = id;
+        this.players = players;
+        this.revealed = revealed;
+        this.allowedSessions = ConcurrentHashMap.newKeySet();
+    }
+
+    public void registerSession(String sessionId) {
+        allowedSessions.add(sessionId);
+    }
+
+    public boolean isSessionAllowed(String sessionId) {
+        return allowedSessions.contains(sessionId);
+    }
 
     public double calculateAverageVote() {
         return players.values().stream()

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -111,7 +111,6 @@
     const cards = [1, 2, 4, 8, 12, 16, 20, 24, 28, null, null];
     const labels = ["1", "2", "4", "8", "12", "16", "20", "24", "28", "I don't know", "Need a break"];
 
-    // ✅ Dołącz do pokoju
     function joinRoom() {
         roomId = document.getElementById("roomId").value;
         playerName = document.getElementById("playerName").value;
@@ -128,9 +127,18 @@
 
         setupWebSocket();
         renderCards();
+
+        // send JOIN communicate after connection
+        setTimeout(() => {
+            stompClient.send(`/app/join/${roomId}`, {}, JSON.stringify({
+                name: playerName,
+                vote: null
+            }));
+            console.log("📨 JOIN sent for player:", playerName);
+        }, 500);
     }
 
-    // ✅ Połącz się z backendem przez STOMP
+    // backend connection through STOMP
     function setupWebSocket() {
         const socket = new SockJS('/poker');
         stompClient = Stomp.over(socket);
@@ -149,7 +157,7 @@
         });
     }
 
-    // ✅ Obsługa wiadomości o stanie pokoju
+    // room status message handler
     function handleMessage(data) {
         if (data.players) {
             const participantCount = Object.keys(data.players).length;
@@ -162,7 +170,6 @@
         }
     }
 
-    // ✅ Wysyłanie głosu
     function sendVote(vote) {
         stompClient.send("/app/poker", {}, JSON.stringify({
             type: "vote",
@@ -172,7 +179,6 @@
         }));
     }
 
-    // ✅ Odsłonięcie kart
     function reveal() {
         stompClient.send("/app/poker", {}, JSON.stringify({
             type: "reveal",
@@ -180,7 +186,6 @@
         }));
     }
 
-    // ✅ Reset głosowania
     function reset() {
         stompClient.send("/app/poker", {}, JSON.stringify({
             type: "reset",
@@ -190,7 +195,7 @@
         document.getElementById("results-body").innerHTML = "";
     }
 
-    // 🃏 Render kart do głosowania
+    //  voting cards render
     function renderCards() {
         const cardsContainer = document.getElementById("cards");
         cardsContainer.innerHTML = "";
@@ -204,7 +209,7 @@
         });
     }
 
-    // 📊 Render tabeli uczestników i głosów
+    // user and votes table render
     function renderResultsTable(players, revealed) {
         const tbody = document.getElementById("results-body");
         tbody.innerHTML = "";


### PR DESCRIPTION
 What’s new:

Added session registration mechanism to link WebSocket sessions with players.
Prevented unauthorized users from sending votes, revealing, or resetting.
Updated frontend to automatically send a JOIN event and display participant list.
Showed participant count in the UI for transparency.


 Why:

To improve security and avoid anonymous users interacting with the game.
To ensure all participants are visible and accounted for during estimation.
To prepare the system for future role-based permissions (e.g., organizer).


 How to test:

Start the application locally.
Join a room as 2–3 different users.
Verify that:
Each participant appears in the table immediately after joining.
Participant count updates correctly.
Unauthorized users (those who haven’t joined) cannot send votes or reveal cards.
Try connecting as a “spy” without joining — they should be ignored.